### PR TITLE
Use an appropriate env name for the TS image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -158,7 +158,7 @@ runs:
         BASE_YUM_REPO=${{ inputs.osg_repo }}
         BASE_OS=${{ inputs.base_os }}
         BASE_OSG_SERIES=${{ inputs.osg_series }}
-        TIMESTAMP_TAG=${{ steps.generate-tags.outputs.ts_image }}
+        TIMESTAMP_IMAGE=${{ steps.generate-tags.outputs.ts_image }}
       tags: ${{ steps.generate-tags.outputs.tag_list }}
       cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
 


### PR DESCRIPTION
For https://github.com/opensciencegrid/osgvo-docker-pilot/pull/118