### PR TITLE
Fix image name bug for the default context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -114,10 +114,10 @@ runs:
          [[ ${{ inputs.context }} == "./" ]]; then
          # Try to guess the image name from our docker repo naming conventions
          # E.g., opensciencegrid/docker-frontier-squid
-         IMAGE_NAME=${GITHUB_REPOSITORY/opensciencegrid\/docker-//}-${DEFAULT_TAG}
+         IMAGE_NAME=${GITHUB_REPOSITORY/opensciencegrid\/docker-//}:${DEFAULT_TAG}
       elif [[ -d ${{ inputs.context }} ]]; then
          # Assume that the containing dir is the image name
-         IMAGE_NAME=$(basename ${{ inputs.context }})-${DEFAULT_TAG}
+         IMAGE_NAME=$(basename ${{ inputs.context }}):${DEFAULT_TAG}
       else
         echo "No output_image provided and ${{ inputs.context }} is not a directory"
         exit 1


### PR DESCRIPTION
I'm not entirely sure how things work without this. Maybe we're pushing to a lot of weird image names in Harbor as a result?

EDIT: looks like we only use this in a few spots (e.g., images and osgvo-docker-pilot repos) and we don't fall down this code path for those repos